### PR TITLE
Handle clipboard copy on Linux

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,4 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Documentation updates, including a walkthrough
 - Short option `-o` for `passage show --on-screen`
+- Fix clipboard copying on Linux. A child process is spawned and keeps the content on the clipboard for 10 seconds. See #5
+- Better presentation on crates.io

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fork"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe7851370a3546121056109b6e5710686b10cc750d45166153eba0477633491"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +524,7 @@ dependencies = [
  "age",
  "anyhow",
  "clipboard",
+ "fork",
  "lazy_static",
  "rpassword",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ rpassword = "4.0"
 structopt = {version="0.3", features=["color"]}
 lazy_static = "1.4"
 clipboard = "0.5"
+fork = "0.1.15"


### PR DESCRIPTION
This is related to an issue with the clipboard handling in xorg,
see https://github.com/aweinstock314/rust-clipboard/issues/61

This now forks a child process and sleeps for 10 seconds, after
which it clears the clipboard before exiting.

Closes #5